### PR TITLE
Adds RestEndpoint to decouple Endpoint from http.

### DIFF
--- a/Sources/Corvus/Endpoints/Create/Create.swift
+++ b/Sources/Corvus/Endpoints/Create/Create.swift
@@ -20,12 +20,4 @@ public final class Create<T: CorvusModel>: QueryEndpoint {
         let requestContent = try req.content.decode(QuerySubject.self)
         return requestContent.save(on: req.db).map { requestContent }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.post(use: handler)
-    }
 }

--- a/Sources/Corvus/Endpoints/Custom.swift
+++ b/Sources/Corvus/Endpoints/Custom.swift
@@ -2,7 +2,7 @@ import Vapor
 import Fluent
 
 /// A class that contains custom functionality passed in by the implementor for
-/// a generic type `T` conforming to `CorvusModel` grouped under a given path.
+/// a generic type `T conforming to `ResponseEncodable` grouped under a given path.
 public final class Custom<R: ResponseEncodable>: RestEndpoint {
     
     /// The return value of the `.handler()`.
@@ -35,7 +35,10 @@ public final class Custom<R: ResponseEncodable>: RestEndpoint {
         self.customHandler = customHandler
     }
 
-    /// Not used, necessary for protocol conformance to `QueryEndpoint`.
+    /// A method to return an element of type `T` return by the custom handler.
+    ///
+    /// - Parameter req: An incoming `Request`.
+    /// - Returns: An element of type `T`.
     public func handler(_ req: Request) throws -> EventLoopFuture<Element> {
         try customHandler(req)
     }

--- a/Sources/Corvus/Endpoints/Custom.swift
+++ b/Sources/Corvus/Endpoints/Custom.swift
@@ -3,22 +3,19 @@ import Fluent
 
 /// A class that contains custom functionality passed in by the implementor for
 /// a generic type `T` conforming to `CorvusModel` grouped under a given path.
-public final class Custom<T: CorvusModel>: QueryEndpoint {
-
+public final class Custom<R: ResponseEncodable>: RestEndpoint {
+    
     /// The return value of the `.handler()`.
-    public typealias Element = T
-
-    /// The return value of the `query()`.
-    public typealias QuerySubject = T
+    public typealias Element = R
 
     /// The path to the component, can be used for route parameters.
-    let path: PathComponent
+    public let pathComponents: [PathComponent]
 
     /// The HTTP method of the `Custom` operation.
     public let operationType: OperationType
 
     /// The custom handler passed in by the implementor.
-    var customHandler: (Request) throws -> EventLoopFuture<QuerySubject>
+    var customHandler: (Request) throws -> EventLoopFuture<Element>
 
     /// Initializes the component with path information, operation type of its
     /// functionality and a custom handler function passed in as a closure.
@@ -29,37 +26,17 @@ public final class Custom<T: CorvusModel>: QueryEndpoint {
     ///     - customHandler: A closure that implements the functionality for the
     ///     `Custom` component.
     public init(
-        path: PathComponent,
+        path: PathComponent...,
         type operationType: OperationType,
         _ customHandler: @escaping (Request) throws -> EventLoopFuture<Element>
     ) {
-        self.path = path
+        self.pathComponents = path
         self.operationType = operationType
         self.customHandler = customHandler
     }
 
     /// Not used, necessary for protocol conformance to `QueryEndpoint`.
     public func handler(_ req: Request) throws -> EventLoopFuture<Element> {
-        try query(req).first().unwrap(or: Abort(.notFound))
-    }
-
-    /// A method that registers the `.handler()` to the supplied
-    /// `RoutesBuilder` based on its `operationType`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        switch operationType {
-        case .post:
-            routes.post(path, use: customHandler)
-        case .get:
-            routes.get(path, use: customHandler)
-        case .put:
-            routes.put(path, use: customHandler)
-        case .delete:
-            routes.delete(path, use: customHandler)
-        case .patch:
-            fatalError("Not implemented yet.")
-        }
+        try customHandler(req)
     }
 }

--- a/Sources/Corvus/Endpoints/Delete/Delete.swift
+++ b/Sources/Corvus/Endpoints/Delete/Delete.swift
@@ -48,12 +48,4 @@ public final class Delete<T: CorvusModel>: AuthEndpoint {
             .flatMap { $0.delete(force: true, on: req.db) }
             .map { .ok }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.delete(use: handler)
-    }
 }

--- a/Sources/Corvus/Endpoints/Delete/SoftDelete.swift
+++ b/Sources/Corvus/Endpoints/Delete/SoftDelete.swift
@@ -50,12 +50,4 @@ public final class SoftDelete<T: CorvusModel>: AuthEndpoint {
             .flatMap { $0.delete(on: req.db) }
             .map { .ok }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.delete(use: handler)
-    }
 }

--- a/Sources/Corvus/Endpoints/Groups/BasicAuthGroup.swift
+++ b/Sources/Corvus/Endpoints/Groups/BasicAuthGroup.swift
@@ -1,8 +1,9 @@
 import Vapor
+import Fluent
 
 /// A special type of `Group` that protects its `content` with basic
 /// authentication.
-public struct BasicAuthGroup: Endpoint {
+public struct BasicAuthGroup<T: ModelUser>: Endpoint {
 
     /// An array of `PathComponent` describing the path that the
     /// `BasicAuthGroup` extends.
@@ -28,9 +29,9 @@ public struct BasicAuthGroup: Endpoint {
     }
 
 
-    /// A method that registers the `content` of the `BearerAuthGroup` to the
+    /// A method that registers the `content` of the `BasicAuthGroup` to the
     /// supplied `RoutesBuilder`. It also registers basic authentication
-    /// middleware using `CorvusUser`.
+    /// middleware using `T` conforming to `ModelUser`.
     ///
     /// - Parameter routes: A `RoutesBuilder` containing all the information
     /// about the HTTP route leading to the current component.
@@ -40,8 +41,8 @@ public struct BasicAuthGroup: Endpoint {
         )
 
         let guardedRoutesBuilder = groupedRoutesBuilder.grouped([
-            CorvusUser.guardMiddleware(),
-            CorvusUser.authenticator().middleware(),
+            T.guardMiddleware(),
+            T.authenticator().middleware(),
         ])
         
         content.register(to: guardedRoutesBuilder)

--- a/Sources/Corvus/Endpoints/Groups/BearerAuthGroup.swift
+++ b/Sources/Corvus/Endpoints/Groups/BearerAuthGroup.swift
@@ -1,14 +1,15 @@
 import Vapor
+import Fluent
 
 /// A special type of `Group` that protects its `content` with bearer token
 /// authentication.
-public struct BearerAuthGroup: Endpoint {
+public struct BearerAuthGroup<T: ModelUserToken>: Endpoint {
 
     /// An array of `PathComponent` describing the path that the
     /// `BearerAuthGroup` extends.
     let pathComponents: [PathComponent]
 
-    /// The content of the `BasicAuthGroup`, which can be any kind of Corvus
+    /// The content of the `BearerAuthGroup`, which can be any kind of Corvus
     /// component.
     public var content: Endpoint
 
@@ -30,7 +31,7 @@ public struct BearerAuthGroup: Endpoint {
 
     /// A method that registers the `content` of the `BearerAuthGroup` to the
     /// supplied `RoutesBuilder`. It also registers basic authentication
-    /// middleware using `CorvusUser`.
+    /// middleware using `T`conforming to `ModelUserToken`.
     ///
     /// - Parameter routes: A `RoutesBuilder` containing all the information
     /// about the HTTP route leading to the current component.
@@ -40,8 +41,8 @@ public struct BearerAuthGroup: Endpoint {
         )
 
         let guardedRoutesBuilder = groupedRoutesBuilder.grouped([
-            CorvusUser.guardMiddleware(),
-            CorvusToken.authenticator().middleware(),
+            T.User.guardMiddleware(),
+            T.authenticator().middleware(),
         ])
         
         content.register(to: guardedRoutesBuilder)

--- a/Sources/Corvus/Endpoints/Modifiers/AuthModifier.swift
+++ b/Sources/Corvus/Endpoints/Modifiers/AuthModifier.swift
@@ -93,26 +93,6 @@ public final class AuthModifier<Q: AuthEndpoint>: AuthEndpoint {
             }
         }
     }
-
-    /// A method that registers the `.handler()` to the supplied
-    /// `RoutesBuilder`, based on the `queryEndpoint`'s operation type.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        switch operationType {
-        case .post:
-            routes.post(use: handler)
-        case .get:
-            routes.get(use: handler)
-        case .put:
-            routes.put(use: handler)
-        case .delete:
-            routes.delete(use: handler)
-        case .patch:
-            fatalError("Not implemented yet")
-        }
-    }
 }
 
 /// An extension that adds the `.auth()` modifier to components conforming to

--- a/Sources/Corvus/Endpoints/Modifiers/Read/ChildrenModifier.swift
+++ b/Sources/Corvus/Endpoints/Modifiers/Read/ChildrenModifier.swift
@@ -65,14 +65,6 @@ ReadEndpoint {
             return eagerLoaded
         }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.get(use: handler)
-    }
 }
 
 /// An extension that adds a `.children()` modifier to `ReadEndpoints`.

--- a/Sources/Corvus/Endpoints/Modifiers/Read/FilterModifier.swift
+++ b/Sources/Corvus/Endpoints/Modifiers/Read/FilterModifier.swift
@@ -52,13 +52,6 @@ public final class FilterModifier<Q: ReadEndpoint>: ReadEndpoint {
         try query(req).all()
     }
 
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.get(use: handler)
-    }
 }
 
 /// An extension that adds a `.filter()` modifier to `ReadEndpoints`.

--- a/Sources/Corvus/Endpoints/Read/ReadAll.swift
+++ b/Sources/Corvus/Endpoints/Read/ReadAll.swift
@@ -37,12 +37,4 @@ public final class ReadAll<T: CorvusModel>: ReadEndpoint {
             ).all()
         }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.get(use: handler)
-    }
 }

--- a/Sources/Corvus/Endpoints/Read/ReadOne.swift
+++ b/Sources/Corvus/Endpoints/Read/ReadOne.swift
@@ -69,12 +69,4 @@ public final class ReadOne<T: CorvusModel>: ReadEndpoint {
                 .unwrap(or: Abort(.notFound))
         }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.get(use: handler)
-    }
 }

--- a/Sources/Corvus/Endpoints/Restore/Restore.swift
+++ b/Sources/Corvus/Endpoints/Restore/Restore.swift
@@ -3,7 +3,7 @@ import Fluent
 
 /// A class that provides functionality to restore soft-deleted objects of a
 /// generic type `T` conforming to `CorvusModel` and identified by a route parameter.
-public final class Restore<T: CorvusModel>: Endpoint {
+public final class Restore<T: CorvusModel>: AuthEndpoint {
 
     /// The return type of the `.handler()`.
     public typealias QuerySubject = T
@@ -13,7 +13,8 @@ public final class Restore<T: CorvusModel>: Endpoint {
 
    /// The ID of the item to be deleted.
     let id: PathComponent
-
+    public let operationType: OperationType = .patch
+    
     // The timestamp at which the item was soft deleted.
     let deletedTimestamp: QuerySubject.Timestamp
     

--- a/Sources/Corvus/Endpoints/Update/Update.swift
+++ b/Sources/Corvus/Endpoints/Update/Update.swift
@@ -51,12 +51,4 @@ public final class Update<T: CorvusModel>: AuthEndpoint {
                 return updatedItem.update(on: req.db).map { updatedItem }
             }
     }
-
-    /// A method that registers the `.handler()` to the supplied `RoutesBuilder`.
-     ///
-     /// - Parameter routes: A `RoutesBuilder` containing all the information
-     /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        routes.put(use: handler)
-    }
 }

--- a/Sources/Corvus/Protocols/Endpoints/Endpoint.swift
+++ b/Sources/Corvus/Protocols/Endpoints/Endpoint.swift
@@ -1,5 +1,4 @@
 import Vapor
-import Fluent
 
 /// A protocol most Corvus components in a hierarchy conform to, so that they
 /// may be treated as the same type interchangeably.

--- a/Sources/Corvus/Protocols/Endpoints/QueryEndpoint.swift
+++ b/Sources/Corvus/Protocols/Endpoints/QueryEndpoint.swift
@@ -4,24 +4,13 @@ import Fluent
 /// A protocol that Corvus components conform to which provide some sort
 /// operation (such as create, read) and which need to run queries on the
 /// application's database.
-public protocol QueryEndpoint: Endpoint {
+public protocol QueryEndpoint: RestEndpoint {
 
     /// The subject of an operation's queries in its `.query()` method.
     associatedtype QuerySubject: CorvusModel
 
-    /// The type returned after operating on a component's `.query()` in its
-    /// `.handler()`.
-    associatedtype Element: ResponseEncodable
-
-    /// The HTTP method of the functionality of the component.
-    var operationType: OperationType { get }
-
     /// A method to run database queries on a component's `QuerySubject`.
     func query(_ req: Request) throws -> QueryBuilder<QuerySubject>
-
-    /// A method that runs logic on the results of the `.query()` and returns
-    /// those results asynchronously in an  `EventLoopFuture`.
-    func handler(_ req: Request) throws -> EventLoopFuture<Element>
 }
 
 /// An extension that provides a default empty database query for those

--- a/Sources/Corvus/Protocols/Endpoints/RestEndpoint.swift
+++ b/Sources/Corvus/Protocols/Endpoints/RestEndpoint.swift
@@ -1,0 +1,37 @@
+import Vapor
+
+public protocol RestEndpoint: Endpoint {
+
+    /// The type returned after from the `.handler()`.
+    associatedtype Element: ResponseEncodable
+
+    /// The HTTP method of the functionality of the component.
+    var operationType: OperationType { get }
+
+    /// An array of `PathComponent` describing the path that the
+    /// `TypedEndpoint` extends.
+    var pathComponents: [PathComponent] { get }
+
+    /// A method that runs logic on the results of the `.query()` and returns
+    /// those results asynchronously in an  `EventLoopFuture`.
+    func handler(_ req: Request) throws -> EventLoopFuture<Element>
+}
+
+public extension RestEndpoint {
+    var pathComponents: [PathComponent] { [] }
+    
+    func register(to routes: RoutesBuilder) {
+        switch operationType {
+        case .post:
+            routes.post(pathComponents, use: handler)
+        case .get:
+            routes.get(pathComponents, use: handler)
+        case .put:
+            routes.put(pathComponents, use: handler)
+        case .delete:
+            routes.delete(pathComponents, use: handler)
+        case .patch:
+            routes.patch(pathComponents, use: handler)
+        }
+    }
+}

--- a/Tests/CorvusTests/ApplicationTests.swift
+++ b/Tests/CorvusTests/ApplicationTests.swift
@@ -292,7 +292,7 @@ final class ApplicationTests: XCTestCase {
 
             var content: Endpoint {
                 Group("api", "accounts") {
-                    Custom<Account>(path: "", type: .post) { req in
+                    Custom<Account>(path: "userId", type: .post) { req in
                         let requestContent = try req.content.decode(
                             Account.self
                         )
@@ -317,7 +317,7 @@ final class ApplicationTests: XCTestCase {
         let account = Account(name: "Berzan")
         try app.testable().test(
             .POST,
-            "/api/accounts",
+            "/api/accounts/userId",
             headers: ["content-type": "application/json"],
             body: account.encode()
         ) { res in

--- a/Tests/CorvusTests/AuthenticationTests.swift
+++ b/Tests/CorvusTests/AuthenticationTests.swift
@@ -12,7 +12,7 @@ final class AuthenticationTests: XCTestCase {
                 Group("api") {
                     CRUD<CorvusUser>("users", softDelete: false)
 
-                    BasicAuthGroup("accounts") {
+                    BasicAuthGroup<CorvusUser>("accounts") {
                         Create<Account>()
                     }
                 }
@@ -77,7 +77,7 @@ final class AuthenticationTests: XCTestCase {
                 Group("api") {
                     CRUD<CorvusUser>("users", softDelete: false)
 
-                    BasicAuthGroup("accounts") {
+                    BasicAuthGroup<CorvusUser>("accounts") {
                         Create<Account>()
                     }
                 }
@@ -134,7 +134,7 @@ final class AuthenticationTests: XCTestCase {
 
                     Login("login")
 
-                    BearerAuthGroup("accounts") {
+                    BearerAuthGroup<CorvusToken>("accounts") {
                         Create<Account>()
                     }
                 }
@@ -206,7 +206,7 @@ final class AuthenticationTests: XCTestCase {
 
                     Login("login")
 
-                    BearerAuthGroup("accounts") {
+                    BearerAuthGroup<CorvusToken>("accounts") {
                         Create<Account>()
                     }
                 }
@@ -248,7 +248,7 @@ final class AuthenticationTests: XCTestCase {
 
                     Login("login")
 
-                    BearerAuthGroup("accounts") {
+                    BearerAuthGroup<CorvusToken>("accounts") {
                         Create<SecureAccount>()
                         Group(testParameter.id) {
                             ReadOne<SecureAccount>(testParameter.id)


### PR DESCRIPTION
This inserts the RestEndpoint protocol in between the Endpoint and QueryEndpoint protocols, to decouple Endpoint from any http specific code.

This also allows Custom to be truly a custom request handler instead of a QueryEndpoint.