### PR TITLE
Provide a functional default implementation of register in Endpoints

### DIFF
--- a/Sources/Corvus/Endpoints/CRUD.swift
+++ b/Sources/Corvus/Endpoints/CRUD.swift
@@ -68,13 +68,4 @@ public final class CRUD<T: CorvusModel>: Endpoint {
             }
         }
     }
-
-    /// A method that invokes the `register` function for the component's
-    /// `content`.
-    ///
-    /// - Parameter routes: A `RoutesBuilder` containing all the information
-    /// about the HTTP route leading to the current component.
-    public func register(to routes: RoutesBuilder) {
-        content.register(to: routes)
-    }
 }

--- a/Sources/Corvus/Endpoints/Utilities/EmptyEndpoint.swift
+++ b/Sources/Corvus/Endpoints/Utilities/EmptyEndpoint.swift
@@ -1,2 +1,7 @@
+import Vapor
+
 /// An empty default value when no `Endpoint` value is needed.
-public struct EmptyEndpoint: Endpoint {}
+public struct EmptyEndpoint: Endpoint {
+    /// An empty default implementation of `.register()` to avoid endless loops when registering `EmptyEndpoint`s
+    public func register(to routes: RoutesBuilder) { }
+}

--- a/Sources/Corvus/Endpoints/Utilities/EventLoopFuture+MapEachThrowing.swift
+++ b/Sources/Corvus/Endpoints/Utilities/EventLoopFuture+MapEachThrowing.swift
@@ -12,7 +12,7 @@ extension EventLoopFuture where Value: Sequence {
     func mapEachThrowing<Result>(
         _ transform: @escaping (_ element: Value.Element) throws -> Result
     ) -> EventLoopFuture<[Result]> {
-        return self.flatMapThrowing { sequence -> [Result] in
+        return self.flatMapThrowing { sequence in
             try sequence.map(transform)
         }
     }

--- a/Sources/Corvus/Endpoints/Utilities/EventLoopFuture+MapEachThrowing.swift
+++ b/Sources/Corvus/Endpoints/Utilities/EventLoopFuture+MapEachThrowing.swift
@@ -12,7 +12,7 @@ extension EventLoopFuture where Value: Sequence {
     func mapEachThrowing<Result>(
         _ transform: @escaping (_ element: Value.Element) throws -> Result
     ) -> EventLoopFuture<[Result]> {
-        return self.flatMapThrowing { sequence in
+        self.flatMapThrowing { sequence in
             try sequence.map(transform)
         }
     }

--- a/Sources/Corvus/Protocols/Endpoints/Endpoint.swift
+++ b/Sources/Corvus/Protocols/Endpoints/Endpoint.swift
@@ -27,9 +27,10 @@ extension Endpoint {
 /// do not need to be registered.
 extension Endpoint {
 
-    /// An empty default implementation of `.register()` for components that do
-    /// not need it.
-    public func register(to routes: RoutesBuilder) {}
+    /// A default implementation of `.register()` for components that do not need special behaviour.
+    public func register(to routes: RoutesBuilder) {
+        content.register(to: routes)
+    }
 }
 
 /// An extension to make an `Array` of `Endpoint` conform to `Endpoint` and thus


### PR DESCRIPTION
Provide a functional default implementation of register in Endpoints
## Description
Provide a functional default implementation of `register(to routes: RoutesBuilder)` for an `Endpoint` to enable Corvus Users to write composable `Endpoint`s without the need to write a `register(to routes: RoutesBuilder)` function

## Related Issue
Closes #7 

## How Has This Been Tested?
Ran the test suite

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
