### PR TITLE
Feature/response modifier

### DIFF
--- a/Sources/Corvus/Endpoints/Modifiers/ResponseModifier.swift
+++ b/Sources/Corvus/Endpoints/Modifiers/ResponseModifier.swift
@@ -1,0 +1,54 @@
+import Vapor
+import Fluent
+
+/// A class that wraps a component which utilizes a `.respond(with:)` modifier. That
+/// allows Corvus to chain modifiers, as it gets treated as any other struct
+/// conforming to `RestEndpoint`.
+public final class ResponseModifier<Q: RestEndpoint, R: CorvusResponse>: RestEndpoint where Q.Element == R.Item {
+    
+    /// The `Response` of this modifier.
+    public typealias Response = R
+    
+    /// The `RestEndpoint` the `.respond(with:)` modifier is attached to.
+    public let restEndpoint: Q
+
+    /// The HTTP operation type of the component.
+    public let operationType: OperationType
+    
+    /// Initializes the modifier with its underlying `RestEndpoint`.
+    ///
+    /// - Parameters:
+    ///     - queryEndpoint: The `QueryEndpoint` which the modifer is attached
+    ///     to.
+    public init(_ restEndpoint: Q) {
+        self.restEndpoint = restEndpoint
+        self.operationType = restEndpoint.operationType
+    }
+    
+    /// A method which transform the restEndpoints's handler return value to a
+    /// `Response`.
+    ///
+    /// - Parameter req: An incoming `Request`.
+    /// - Returns: An `EventLoopFuture` containing the
+    /// `ResponseModifier`'s `Response`.
+    public func handler(_ req: Request)
+        throws -> EventLoopFuture<Response> {
+            try restEndpoint.handler(req).map(Response.init)
+    }
+
+}
+
+/// An extension that adds a `.respond(with:)` modifier to `RestEndpoint`.
+extension RestEndpoint {
+
+    /// A modifier used to transform the values returned by a component using a
+    /// `CorvusResponse`.
+    ///
+    /// - Parameter as: A type conforming to `CorvusResponse`.
+    /// - Returns: An instance of a `ResponseModifier` with the supplied `CorvusResponse`.
+    public func respond<R: CorvusResponse>(
+        with: R.Type
+    ) -> ResponseModifier<Self, R> {
+        ResponseModifier(self)
+    }
+}

--- a/Sources/Corvus/Endpoints/Modifiers/ResponseModifier.swift
+++ b/Sources/Corvus/Endpoints/Modifiers/ResponseModifier.swift
@@ -4,7 +4,10 @@ import Fluent
 /// A class that wraps a component which utilizes a `.respond(with:)` modifier. That
 /// allows Corvus to chain modifiers, as it gets treated as any other struct
 /// conforming to `RestEndpoint`.
-public final class ResponseModifier<Q: RestEndpoint, R: CorvusResponse>: RestEndpoint where Q.Element == R.Item {
+public final class ResponseModifier<
+    Q: RestEndpoint,
+    R: CorvusResponse>:
+RestEndpoint where Q.Element == R.Item {
     
     /// The `Response` of this modifier.
     public typealias Response = R

--- a/Sources/Corvus/Protocols/http/CorvusResponse.swift
+++ b/Sources/Corvus/Protocols/http/CorvusResponse.swift
@@ -1,0 +1,6 @@
+import Vapor
+
+public protocol CorvusResponse: Content {
+    associatedtype Item
+    init(item: Item)
+}

--- a/Sources/Corvus/Protocols/http/CorvusResponse.swift
+++ b/Sources/Corvus/Protocols/http/CorvusResponse.swift
@@ -1,6 +1,14 @@
 import Vapor
 
+/// `CorvusResponse` is a wrapper type for the result of`QueryEndpoint`s. Can
+/// be used to add metadata to a response.
+///
 public protocol CorvusResponse: Content {
+    
+    /// The item is equivalent to the `QueryEndpoint`'s `QuerySubject`.
     associatedtype Item
+    
+    /// Initialises a `CorvusResponse` with a given item.
+    /// Normally this is the result of the `QueryEndpoints`'s handler function.
     init(item: Item)
 }

--- a/Tests/CorvusTests/ApplicationTests.swift
+++ b/Tests/CorvusTests/ApplicationTests.swift
@@ -675,6 +675,70 @@ final class ApplicationTests: XCTestCase {
                 XCTAssertEqual(res.status, .notFound)
         }
     }
+    
+    func testResponseModifier() throws {
+        
+        // This is a basic response.
+        struct CreateResponse: CorvusResponse, Equatable {
+            let created = true
+            let name: String
+            
+            init(item: Account) {
+                self.name = item.name
+            }
+        }
+        
+        // This response is a more complex example using generics.
+        // This allows for responses which work with any number of models.
+        struct ReadResponse<Model: AnyModel & Equatable>: CorvusResponse, Equatable {
+            let success = true
+            let payload: [Model]
+            
+            init(item: [Model]) {
+                payload = item
+            }
+        }
+        
+        final class ResponseModifierTest: RestApi {
+
+            let testParameter = Parameter<Account>()
+
+            var content: Endpoint {
+                Group("api", "accounts") {
+                    Create<Account>().respond(with: CreateResponse.self)
+                    ReadAll<Account>().respond(with: ReadResponse.self)
+                }
+            }
+        }
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        let readOneTest = ResponseModifierTest()
+
+        app.databases.use(.sqlite(.memory), as: .test, isDefault: true)
+        app.migrations.add(CreateAccount())
+
+        try app.autoMigrate().wait()
+        
+        try app.register(collection: readOneTest)
+        
+        let account = Account(name: "Berzan")
+        let createRes = CreateResponse(item: account)
+        let readRes = ReadResponse(item: [account])
+        
+        try app.testable().test(
+            .POST,
+            "/api/accounts",
+            headers: ["content-type": "application/json"],
+            body: account.encode(),
+            afterResponse: { res in
+                XCTAssertEqualJSON(res.body.string, createRes)
+            }
+        ).test(.GET, "/api/accounts/") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqualJSON(res.body.string, readRes)
+        }
+    }
 }
 
 extension DatabaseID {


### PR DESCRIPTION
Provide a way to annotate/customize the response body

## Description
Add a `ResponseModifier` which maps the return value of the `handler` method to a `CorvusResponse` type. This type conforms to ResponseEncodable and can thus be returned to the user.

## Related Issue
Closes 50% of #3 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] SwiftLint throws no warnings or errors.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.