### PR TITLE
[FEATURE] User endpoint auto-hash and validate

### DIFF
--- a/Sources/Corvus/Authentication/CorvusModelAuthenticatable.swift
+++ b/Sources/Corvus/Authentication/CorvusModelAuthenticatable.swift
@@ -18,8 +18,8 @@ public protocol CorvusModelAuthenticatable: CorvusModel, Authenticatable {
 }
 
 /// An extension to provide an authenticator for the user that can be
-/// registered to the `Vapor` application, and field accessors for `username` and
-/// `password`.
+/// registered to the `Vapor` application, and field accessors for `username` 
+/// and `password`.
 extension CorvusModelAuthenticatable {
 
     /// Provides a `Vapor` authenticator defined below.
@@ -55,7 +55,7 @@ extension CorvusModelAuthenticatable {
 /// Provides a `BasicAuthenticator` struct that defines how users are
 /// authenticated.
 public struct CorvusModelAuthenticator<User: CorvusModelAuthenticatable>:
-    BasicAuthenticator
+BasicAuthenticator
 {
     /// The database the user is saved in.
     public let database: DatabaseID?

--- a/Sources/Corvus/Authentication/CorvusModelAuthenticatable.swift
+++ b/Sources/Corvus/Authentication/CorvusModelAuthenticatable.swift
@@ -1,5 +1,86 @@
+import Vapor
 import Fluent
 
-/// A protocol that wraps `Vapor`'s `ModelAuthenticatable`
-/// for consistency in naming.
-public protocol CorvusModelAuthenticatable: ModelAuthenticatable {}
+// swiftlint:disable identifier_name
+
+/// A protocol that defines bearer authentication tokens, similar to
+/// `ModelAuthenticatable`.
+public protocol CorvusModelAuthenticatable: CorvusModel, Authenticatable {
+    
+    /// The name of the user.
+    var username: String { get set }
+    
+    /// The hashed password of the user.
+    var password: String { get set }
+    
+    /// A function to verify a given password against the user's.
+    func verify(password: String) throws -> Bool
+}
+
+/// An extension to provide an authenticator for the user that can be
+/// registered to the `Vapor` application, and field accessors for `username` and
+/// `password`.
+extension CorvusModelAuthenticatable {
+
+    /// Provides a `Vapor` authenticator defined below.
+    /// - Parameter database: The database to authenticate.
+    /// - Returns: A `CorvusModelAuthenticator`.
+    public static func authenticator(
+        database: DatabaseID? = nil
+    ) -> CorvusModelAuthenticator<Self> {
+        CorvusModelAuthenticator<Self>(database: database)
+    }
+
+    /// Provides access to the `username` attribute.
+    var _$username: Field<String> {
+        guard let mirror = Mirror(reflecting: self).descendant("_username"),
+            let username = mirror as? Field<String> else {
+                fatalError("username property must be declared using @Field")
+        }
+
+        return username
+    }
+
+    /// Provides access to the `password` attribute.
+    var _$password: Field<String> {
+        guard let mirror = Mirror(reflecting: self).descendant("_password"),
+            let password = mirror as? Field<String> else {
+                fatalError("password property must be declared using @Parent")
+        }
+
+        return password
+    }
+}
+
+/// Provides a `BasicAuthenticator` struct that defines how users are
+/// authenticated.
+public struct CorvusModelAuthenticator<User: CorvusModelAuthenticatable>:
+    BasicAuthenticator
+{
+    /// The database the user is saved in.
+    public let database: DatabaseID?
+
+    /// Authenticates a user.
+    /// - Parameters:
+    ///   - basic: The username and password passed in the request.
+    ///   - request: The `Request` to be authenticated.
+    /// - Returns: An empty `EventLoopFuture`.
+    public func authenticate(
+        basic: BasicAuthorization,
+        for request: Request
+    ) -> EventLoopFuture<Void> {
+        User.query(on: request.db(self.database))
+            .filter(\User._$username == basic.username)
+            .first()
+            .flatMapThrowing
+        {
+            guard let user = $0 else {
+                return
+            }
+            guard try user.verify(password: basic.password) else {
+                return
+            }
+            request.auth.login(user)
+        }
+    }
+}

--- a/Sources/Corvus/Authentication/CorvusModelTokenAuthenticatable.swift
+++ b/Sources/Corvus/Authentication/CorvusModelTokenAuthenticatable.swift
@@ -4,7 +4,7 @@ import Fluent
 // swiftlint:disable identifier_name
 
 /// A protocol that defines bearer authentication tokens, similar to
-/// `CorvusModelTokenAuthenticatable`.
+/// `ModelTokenAuthenticatable`.
 public protocol CorvusModelTokenAuthenticatable: CorvusModel, Authenticatable {
     /// The `User` type the token belongs to.
      associatedtype User: CorvusModel & Authenticatable

--- a/Sources/Corvus/Authentication/CorvusUser.swift
+++ b/Sources/Corvus/Authentication/CorvusUser.swift
@@ -16,8 +16,8 @@ public final class CorvusUser: CorvusModel {
     public var username: String
 
     /// The hashed password of the user, used during authentication.
-    @Field(key: "password_hash")
-    public var passwordHash: String
+    @Field(key: "password")
+    public var password: String
 
     /// Timestamp for soft deletion.
     @Timestamp(key: "deleted_at", on: .delete)
@@ -31,15 +31,15 @@ public final class CorvusUser: CorvusModel {
     /// - Parameters:
     ///     - id: The identifier of the user, auto generated if not provided.
     ///     - username: The username of the user.
-    ///     - passwordHash: The hashed password of the user.
+    ///     - password: The hashed password of the user.
     public init(
         id: UUID? = nil,
         username: String,
-        passwordHash: String
+        password: String
     ) {
         self.id = id
         self.username = username
-        self.passwordHash = passwordHash
+        self.password = password
     }
 }
 
@@ -56,7 +56,7 @@ public struct CreateCorvusUser: Migration {
         database.schema(CorvusUser.schema)
             .id()
             .field("username", .string, .required)
-            .field("password_hash", .string, .required)
+            .field("password", .string, .required)
             .field("deleted_at", .date)
             .create()
     }
@@ -69,16 +69,11 @@ public struct CreateCorvusUser: Migration {
     }
 }
 
-/// An extension to conform to the `CorvusModelUser` protocol, which provides
-/// functionality to authenticate a user with username and password.
+/// An extension to conform to the `CorvusModelAuthenticatable` protocol, which
+/// provides functionality to authenticate a user with username and password.
 extension CorvusUser: CorvusModelAuthenticatable {
+
     
-    /// Provides a path to the user's username.
-    public static let usernameKey = \CorvusUser.$username
-
-    /// Provides a path to the user's hashed password.
-    public static let passwordHashKey = \CorvusUser.$passwordHash
-
     /// Verifies a given string by checking if it matches a user's password.
     ///
     /// - Parameter password: The password to verify.
@@ -86,6 +81,6 @@ extension CorvusUser: CorvusModelAuthenticatable {
     /// not.
     /// - Throws: An error if encryption fails.
     public func verify(password: String) throws -> Bool {
-        try Bcrypt.verify(password, created: self.passwordHash)
+        try Bcrypt.verify(password, created: self.password)
     }
 }

--- a/Sources/Corvus/Endpoints/User.swift
+++ b/Sources/Corvus/Endpoints/User.swift
@@ -34,6 +34,9 @@ public final class User<T: CorvusModelAuthenticatable & CorvusModel>: Endpoint {
         return Group(pathComponents) {
             Custom<HTTPStatus>(type: .post) { req in
                 let requestContent = try req.content.decode(T.self)
+                requestContent.password = try Bcrypt.hash(
+                    requestContent.password
+                )
                 return requestContent.save(on: req.db).map { .ok }
             }
             
@@ -54,6 +57,9 @@ public final class User<T: CorvusModelAuthenticatable & CorvusModel>: Endpoint {
         Group(pathComponents) {
             Custom<HTTPStatus>(type: .post) { req in
                 let requestContent = try req.content.decode(T.self)
+                requestContent.password = try Bcrypt.hash(
+                    requestContent.password
+                )
                 return requestContent.save(on: req.db).map { .ok }
             }
             

--- a/Tests/CorvusTests/AuthenticationTests.swift
+++ b/Tests/CorvusTests/AuthenticationTests.swift
@@ -40,7 +40,7 @@ final class AuthenticationTests: XCTestCase {
         
         let user = CorvusUser(
             username: "berzan",
-            passwordHash: try Bcrypt.hash("pass")
+            password: "pass"
         )
 
         let account = Account(name: "Berzan")
@@ -95,7 +95,7 @@ final class AuthenticationTests: XCTestCase {
         
         let user = CorvusUser(
             username: "berzan",
-            passwordHash: try Bcrypt.hash("pass")
+            password: "pass"
         )
         let account = Account(name: "berzan")
         
@@ -153,7 +153,7 @@ final class AuthenticationTests: XCTestCase {
         
         let user = CorvusUser(
             username: "berzan",
-            passwordHash: try Bcrypt.hash("pass")
+            password: "pass"
         )
         let account = Account(name: "berzan")
         
@@ -274,12 +274,12 @@ final class AuthenticationTests: XCTestCase {
 
         let user1 = CorvusUser(
              username: "berzan",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CorvusUser(
              username: "paul",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         var account: SecureAccount!
@@ -406,14 +406,14 @@ final class AuthenticationTests: XCTestCase {
              username: "berzan",
              surname: "yildiz",
              email: "berzan@corvus.com",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CustomUser(
              username: "paul",
              surname: "schmiedmayer",
              email: "paul@corvus.com",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         var account: CustomAccount!
@@ -524,12 +524,12 @@ final class AuthenticationTests: XCTestCase {
 
         let user1 = CorvusUser(
              username: "berzan",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CorvusUser(
              username: "paul",
-             passwordHash: try Bcrypt.hash("pass")
+             password: "pass"
          )
 
         let basic1 = "berzan:pass"
@@ -609,12 +609,12 @@ final class AuthenticationTests: XCTestCase {
 
            let user1 = CorvusUser(
                 username: "berzan",
-                passwordHash: try Bcrypt.hash("pass")
+                password: try Bcrypt.hash("pass")
             )
 
            let user2 = CorvusUser(
                 username: "paul",
-                passwordHash: try Bcrypt.hash("pass")
+                password: try Bcrypt.hash("pass")
             )
 
            let basic1 = "berzan:pass"
@@ -699,12 +699,12 @@ final class AuthenticationTests: XCTestCase {
 
         let user1 = CorvusUser(
              username: "berzan",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CorvusUser(
              username: "paul",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let basic1 = "berzan:pass"
@@ -802,12 +802,12 @@ final class AuthenticationTests: XCTestCase {
 
         let user1 = CorvusUser(
              username: "berzan",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CorvusUser(
              username: "paul",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         var account: SecureAccount!
@@ -928,12 +928,12 @@ final class AuthenticationTests: XCTestCase {
 
            let user1 = CorvusUser(
                 username: "berzan",
-                passwordHash: try Bcrypt.hash("pass")
+                password: try Bcrypt.hash("pass")
             )
 
            let user2 = CorvusUser(
                 username: "paul",
-                passwordHash: try Bcrypt.hash("pass")
+                password: try Bcrypt.hash("pass")
             )
 
            var account: SecureAccount!
@@ -1055,12 +1055,12 @@ final class AuthenticationTests: XCTestCase {
 
         let user1 = CorvusUser(
              username: "berzan",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         let user2 = CorvusUser(
              username: "paul",
-             passwordHash: try Bcrypt.hash("pass")
+             password: try Bcrypt.hash("pass")
          )
 
         var account1: SecureAccount!

--- a/Tests/CorvusTests/AuthenticationTests.swift
+++ b/Tests/CorvusTests/AuthenticationTests.swift
@@ -559,14 +559,22 @@ final class AuthenticationTests: XCTestCase {
                 body: user2.encode()
              )
             .test(
+               .POST,
+               "/api/users",
+               headers: ["content-type": "application/json"],
+               body: user2.encode()
+            ) { res in
+                XCTAssertEqual(res.status, .badRequest)
+            }
+            .test(
                   .GET,
                   "/api/users/\(userRes.id!)",
                   headers: [
                       "Authorization": "Basic \(basic2)"
                   ]
-                ) { res in
-                    XCTAssertEqual(res.status, .unauthorized)
-                }
+            ) { res in
+                XCTAssertEqual(res.status, .unauthorized)
+            }
             .test(
                   .GET,
                   "/api/users/\(userRes.id!)",

--- a/Tests/CorvusTests/Models/CustomUser.swift
+++ b/Tests/CorvusTests/Models/CustomUser.swift
@@ -19,8 +19,8 @@ public final class CustomUser: CorvusModel, Authenticatable {
     @Field(key: "email")
     public var email: String
 
-    @Field(key: "password_hash")
-    public var passwordHash: String
+    @Field(key: "password")
+    public var password: String
 
     @Timestamp(key: "deleted_at", on: .delete)
     var deletedAt: Date?
@@ -32,13 +32,13 @@ public final class CustomUser: CorvusModel, Authenticatable {
         username: String,
         surname: String,
         email: String,
-        passwordHash: String
+        password: String
     ) {
         self.id = id
         self.username = username
         self.surname = surname
         self.email = email
-        self.passwordHash = passwordHash
+        self.password = password
     }
 }
 
@@ -52,7 +52,7 @@ public struct CreateCustomUser: Migration {
             .field("username", .string, .required)
             .field("surname", .string, .required)
             .field("email", .string, .required)
-            .field("password_hash", .string, .required)
+            .field("password", .string, .required)
             .field("deleted_at", .date)
             .create()
     }
@@ -63,13 +63,9 @@ public struct CreateCustomUser: Migration {
 }
 
 extension CustomUser: CorvusModelAuthenticatable {
-
-    public static let usernameKey = \CustomUser.$username
-
-    public static let passwordHashKey = \CustomUser.$passwordHash
-
+    
     public func verify(password: String) throws -> Bool {
-        try Bcrypt.verify(password, created: self.passwordHash)
+        try Bcrypt.verify(password, created: self.password)
     }
 }
 


### PR DESCRIPTION
The User Endpoint is missing some functionality that I have implemented using a custom endpoint. E.g. when creating a User you should not need to calculate the Hash yourself. In additon some check if a user already exist should be in there, e.g. a unique username.

## Description
Auto hash password upon creation of a user with the `User` component and also check if that username is already taken.

## Related Issue
Closes #22 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] SwiftLint throws no warnings or errors.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


